### PR TITLE
Add key prop to single component reveal example in use-transition page

### DIFF
--- a/src/pages/use-transition.js
+++ b/src/pages/use-transition.js
@@ -98,7 +98,7 @@ const transitions = useTransition(show, null, {
   leave: { opacity: 0 },
 })
 return transitions.map(({ item, key, props }) =>
-  item && <animated.div style={props}>✌️</animated.div>
+  item && <animated.div key={key} style={props}>✌️</animated.div>
 )`}</FencedCode>
           <RewindSpring>{x => <animated.div style={{opacity: x}}>✌️</animated.div>}</RewindSpring>
         </div>


### PR DESCRIPTION
When the key prop is omitted the single component transition doesn't work as expected (i.e. transition stutters / restarts).