### PR TITLE
Use useLocation instead of private __RouterContext

### DIFF
--- a/src/pages/md/useTransition-2.md
+++ b/src/pages/md/useTransition-2.md
@@ -35,7 +35,7 @@ useTransition(items, items => items.id, {
 ### Transitioning [between routes](https://twitter.com/0xca0a/status/1092772431087964161)
 
 ```jsx
-const { location } = useRouter()
+const location = useLocation()
 const transitions = useTransition(location, location => location.pathname, { ... })
 return transitions.map(({ item, props, key }) => (
   <animated.div key={key} style={props}>


### PR DESCRIPTION
I'm trying to find all the places that people are using __RouterContext and update them to use the hooks we just shipped in React Router 5.1. The stuff on __RouterContext is liable to change real soon, and I don't want to break your example! 💕