### PR TITLE
useTransition dependency array

### DIFF
--- a/content/v9/breaking-changes.mdx
+++ b/content/v9/breaking-changes.mdx
@@ -9,8 +9,8 @@ This page is all about breaking changes between v8.x and v9.x. Get ready to upgr
 The new `useTransition` is used like this:
 
 ```js
-// 1. Provide items and props
-const transition = useTransition(items, props)
+// 1. Provide items and props (and dependency array if required)
+const transition = useTransition(items, props, [])
 // 2. Map the items into a fragment
 const fragment = transition((style, item) => {
   // 3. Render each item


### PR DESCRIPTION
I was just getting stuck on a feedback loop with `useTransition` and realised I hadn't included a dependency array (as mentioned on the first page for the v9 docs)