### PR TITLE
Fix reference to new `damping` config property

### DIFF
--- a/src/pages/common/configs.mdx
+++ b/src/pages/common/configs.mdx
@@ -21,7 +21,7 @@ useEffect(() => {
 }, [])
 ```
 
-And we've added the following properties `frequency`, `dampening`, `round`, `bounce`, `progress` & `restVelocity`.
+And we've added the following properties `frequency`, `damping`, `round`, `bounce`, `progress` & `restVelocity`.
 
 | Property     | Default   | Description                                                                                                                                                                                                       |
 | ------------ | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
It said "damp*en*ing" instead of "damping."