### PR TITLE
docs: add Parallax

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@mdx-js/loader": "^1.6.22",
     "@mdx-js/react": "^1.6.22",
     "@next/mdx": "^10.1.3",
+    "@react-spring/parallax": "^9.1.1",
     "clsx": "^1.1.1",
     "lodash-move": "^1.1.1",
     "lodash.clamp": "^4.0.3",

--- a/src/components/CodeBlock/reactLiveScope.tsx
+++ b/src/components/CodeBlock/reactLiveScope.tsx
@@ -79,7 +79,7 @@ const springScope = {
   SpringRef,
   Transition,
   Parallax,
-  ParallaxLayer
+  ParallaxLayer,
 }
 
 const reactScope = {

--- a/src/components/CodeBlock/reactLiveScope.tsx
+++ b/src/components/CodeBlock/reactLiveScope.tsx
@@ -17,6 +17,7 @@ import {
   SpringRef,
   Transition,
 } from '@react-spring/web'
+import { Parallax, ParallaxLayer } from '@react-spring/parallax'
 import { mdx } from '@mdx-js/react'
 import useMeasure from 'react-use-measure'
 // import VisibilitySensor from 'react-visibility-sensor'
@@ -77,6 +78,8 @@ const springScope = {
   Spring,
   SpringRef,
   Transition,
+  Parallax,
+  ParallaxLayer
 }
 
 const reactScope = {

--- a/src/pages/components/parallax.mdx
+++ b/src/pages/components/parallax.mdx
@@ -45,7 +45,7 @@ import { Parallax, ParallaxLayer } from 'react-spring'
 | speed?  | number | Rate at which the layer moves in relation to scroll. Can be positive or negative. Defaults to `0`                                                 |
 
 
-**USAGE NOTES**:
+### Usage Notes
 
 - The `offset` prop is where the layer will end up, not where it begins. For example, if a layer has an offset of `1.5`, it will be halfway down the second page (zero-indexed) when the second page completely fills the viewport.
 - The `speed` prop will affect the initial starting position of a layer, but not it's final `offset` position.

--- a/src/pages/components/parallax.mdx
+++ b/src/pages/components/parallax.mdx
@@ -3,7 +3,55 @@
 ## Overview
 
 ```js
-import { Parallax } from 'react-spring'
+import { Parallax, ParallaxLayer } from 'react-spring'
 ```
 
-> 🚧 Oh no, that's embarrasing. It looks like we don't have the knowledge to fill this page in. If you think you do, please consider submitting a [PR](https://github.com/pmndrs/react-spring.io) 🚧
+`Parallax` creates a scrollable container. `ParallaxLayer`s contain your content and will be moved according to their offsets and speeds.
+
+**NOTE**: Currently, only `@react-spring/web` is supported.
+
+```js
+<Parallax ref={ref} pages={3} horizontal>
+  <ParallaxLayer offset={0} speed={0.5}>
+    <span
+      onClick={() => {ref.current.scrollTo(1)}}
+    >
+      Layers can contain anything
+    </span>
+  </ParallaxLayer>
+</Parallax>
+```
+
+## Parallax
+
+**Props**:
+- `pages: number`  
+Total space of the container. Each page takes up 100% of the viewport.
+- `config?: SpringConfig`  
+The spring behavior. Defaults to `config.slow` (see [configs](/common/configs)).
+- `scrolling?: boolean`  
+Whether or not the content can be scrolled. Defaults to `true`.
+- `horizontal?: boolean`  
+Whether or not the content scrolls horizontally. Defaults to `false`.
+
+### `scrollTo`
+`Parallax` also has a `scrollTo` function for click-to-scroll. It takes one paramater: the number of the page to scroll to 
+(Pages are zero-indexed so `scrollTo(0)` will scroll to the first page, etc).
+
+## ParallaxLayer
+
+**Props**:
+- `factor?: number`  
+Size of the layer relative to page size (eg: `1` => 100%, `1.5` => 150%, etc).
+Defaults to `1`.
+- `offset?: number`  
+The offset of the layer when it's corresponding page is fully in view (eg: `0` => top of 1st page, `1` => top of 2nd page, etc ).
+Defaults to `0`.
+- `speed?: number`  
+Rate at which the layer moves in relation to scroll. Can be positive or negative.
+Defaults to `0`.
+
+**USAGE NOTES**:
+
+- The `offset` prop is where the layer will end up, not where it begins. For example, if a layer has an offset of `1.5`, it will be halfway down the second page (zero-indexed) when the second page completely fills the viewport.
+- The `speed` prop will affect the initial starting position of a layer, but not it's final `offset` position.

--- a/src/pages/components/parallax.mdx
+++ b/src/pages/components/parallax.mdx
@@ -1,3 +1,9 @@
+import { DemoGrid } from 'components/Demo/DemoGrid'
+import { Demo } from 'components/Demo/Demo'
+
+import ParallaxVert from 'demos/parallax-vert/src/App'
+import Parallax from 'demos/parallax/src/App'
+
 # Parallax
 
 ## Overview
@@ -11,30 +17,28 @@ import { Parallax, ParallaxLayer } from '@react-spring/parallax'
 **NOTE**: Currently, only `@react-spring/web` is supported.
 
 ```jsx render=true edit=true
-<Parallax pages={2} style={{top: "0", left: "0"}}>
-  <ParallaxLayer 
-    offset={0} 
-    speed={2.5} 
-    style={{display: "flex", justifyContent: "center", alignItems: "center"}}
-  >
+<Parallax pages={2} style={{ top: '0', left: '0' }}>
+  <ParallaxLayer
+    offset={0}
+    speed={2.5}
+    style={{ display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
     <p>Scroll down</p>
   </ParallaxLayer>
 
-  <ParallaxLayer 
-    offset={1} 
-    speed={2} 
-    style={{backgroundColor: "#ff6d6d"}}
-  />
+  <ParallaxLayer offset={1} speed={2} style={{ backgroundColor: '#ff6d6d' }} />
 
-  <ParallaxLayer 
-    offset={1} 
-    speed={0.5} 
-    style={{display: "flex", justifyContent: "center", alignItems: "center", color: "white"}}
-  >
+  <ParallaxLayer
+    offset={1}
+    speed={0.5}
+    style={{
+      display: 'flex',
+      justifyContent: 'center',
+      alignItems: 'center',
+      color: 'white',
+    }}>
     <p>Scroll up</p>
   </ParallaxLayer>
 </Parallax>
-
 ```
 
 ## Parallax
@@ -64,4 +68,13 @@ import { Parallax, ParallaxLayer } from '@react-spring/parallax'
 - The `offset` prop is where the layer will end up, not where it begins. For example, if a layer has an offset of `1.5`, it will be halfway down the second page (zero-indexed) when the second page completely fills the viewport.
 - The `speed` prop will affect the initial starting position of a layer, but not it's final `offset` position.
 
-## Demo
+## Demos
+
+<DemoGrid>
+  <Demo title="Parallax">
+    <Parallax />
+  </Demo>
+  <Demo title="Parallax Vert">
+    <ParallaxVert />
+  </Demo>
+</DemoGrid>

--- a/src/pages/components/parallax.mdx
+++ b/src/pages/components/parallax.mdx
@@ -24,15 +24,13 @@ import { Parallax, ParallaxLayer } from 'react-spring'
 
 ## Parallax
 
-**Props**:
-- `pages: number`  
-Total space of the container. Each page takes up 100% of the viewport.
-- `config?: SpringConfig`  
-The spring behavior. Defaults to `config.slow` (see [configs](/common/configs)).
-- `scrolling?: boolean`  
-Whether or not the content can be scrolled. Defaults to `true`.
-- `horizontal?: boolean`  
-Whether or not the content scrolls horizontally. Defaults to `false`.
+|Property     | Type         | Description                                                                      |
+|-------------|--------------|----------------------------------------------------------------------------------|
+| pages       | number       | Total space of the container. Each page takes up 100% of the viewport.           |
+| config?     | SpringConfig | The spring behavior. Defaults to `config.slow` (see [configs](/common/configs)). |
+| scrolling?  | boolean      | Whether or not the content can be scrolled. Defaults to `true`.                  |
+| horizontal? | boolean      | Whether or not the content scrolls horizontally. Defaults to `false`.            |
+
 
 ### `scrollTo`
 `Parallax` also has a `scrollTo` function for click-to-scroll. It takes one paramater: the number of the page to scroll to 
@@ -40,16 +38,12 @@ Whether or not the content scrolls horizontally. Defaults to `false`.
 
 ## ParallaxLayer
 
-**Props**:
-- `factor?: number`  
-Size of the layer relative to page size (eg: `1` => 100%, `1.5` => 150%, etc).
-Defaults to `1`.
-- `offset?: number`  
-The offset of the layer when it's corresponding page is fully in view (eg: `0` => top of 1st page, `1` => top of 2nd page, etc ).
-Defaults to `0`.
-- `speed?: number`  
-Rate at which the layer moves in relation to scroll. Can be positive or negative.
-Defaults to `0`.
+|Property | Type   | Description                                                                                                                                       |
+|---------|--------|---------------------------------------------------------------------------------------------------------------------------------------------------|
+| factor? | number | Size of the layer relative to page size (eg: `1` => 100%, `1.5` => 150%, etc). Defaults to `1`                                                    |
+| offset? | number | The offset of the layer when it's corresponding page is fully in view (eg: `0` => top of 1st page, `1` => top of 2nd page, etc ). Defaults to `0` |
+| speed?  | number | Rate at which the layer moves in relation to scroll. Can be positive or negative. Defaults to `0`                                                 |
+
 
 **USAGE NOTES**:
 

--- a/src/pages/components/parallax.mdx
+++ b/src/pages/components/parallax.mdx
@@ -3,49 +3,65 @@
 ## Overview
 
 ```js
-import { Parallax, ParallaxLayer } from 'react-spring'
+import { Parallax, ParallaxLayer } from '@react-spring/parallax'
 ```
 
 `Parallax` creates a scrollable container. `ParallaxLayer`s contain your content and will be moved according to their offsets and speeds.
 
 **NOTE**: Currently, only `@react-spring/web` is supported.
 
-```js
-<Parallax ref={ref} pages={3} horizontal>
-  <ParallaxLayer offset={0} speed={0.5}>
-    <span
-      onClick={() => {ref.current.scrollTo(1)}}
-    >
-      Layers can contain anything
-    </span>
+```jsx render=true edit=true
+<Parallax pages={2} style={{top: "0", left: "0"}}>
+  <ParallaxLayer 
+    offset={0} 
+    speed={2.5} 
+    style={{display: "flex", justifyContent: "center", alignItems: "center"}}
+  >
+    <p>Scroll down</p>
+  </ParallaxLayer>
+
+  <ParallaxLayer 
+    offset={1} 
+    speed={2} 
+    style={{backgroundColor: "#ff6d6d"}}
+  />
+
+  <ParallaxLayer 
+    offset={1} 
+    speed={0.5} 
+    style={{display: "flex", justifyContent: "center", alignItems: "center", color: "white"}}
+  >
+    <p>Scroll up</p>
   </ParallaxLayer>
 </Parallax>
+
 ```
 
 ## Parallax
 
-|Property     | Type         | Description                                                                      |
-|-------------|--------------|----------------------------------------------------------------------------------|
+| Property    | Type         | Description                                                                      |
+| ----------- | ------------ | -------------------------------------------------------------------------------- |
 | pages       | number       | Total space of the container. Each page takes up 100% of the viewport.           |
 | config?     | SpringConfig | The spring behavior. Defaults to `config.slow` (see [configs](/common/configs)). |
 | scrolling?  | boolean      | Whether or not the content can be scrolled. Defaults to `true`.                  |
 | horizontal? | boolean      | Whether or not the content scrolls horizontally. Defaults to `false`.            |
 
-
 ### `scrollTo`
-`Parallax` also has a `scrollTo` function for click-to-scroll. It takes one paramater: the number of the page to scroll to 
+
+`Parallax` also has a `scrollTo` function for click-to-scroll. It takes one paramater: the number of the page to scroll to
 (Pages are zero-indexed so `scrollTo(0)` will scroll to the first page, etc).
 
 ## ParallaxLayer
 
-|Property | Type   | Description                                                                                                                                       |
-|---------|--------|---------------------------------------------------------------------------------------------------------------------------------------------------|
-| factor? | number | Size of the layer relative to page size (eg: `1` => 100%, `1.5` => 150%, etc). Defaults to `1`                                                    |
-| offset? | number | The offset of the layer when it's corresponding page is fully in view (eg: `0` => top of 1st page, `1` => top of 2nd page, etc ). Defaults to `0` |
-| speed?  | number | Rate at which the layer moves in relation to scroll. Can be positive or negative. Defaults to `0`                                                 |
-
+| Property | Type   | Description                                                                                                                                       |
+| -------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| factor?  | number | Size of the layer relative to page size (eg: `1` => 100%, `1.5` => 150%, etc). Defaults to `1`                                                    |
+| offset?  | number | The offset of the layer when it's corresponding page is fully in view (eg: `0` => top of 1st page, `1` => top of 2nd page, etc ). Defaults to `0` |
+| speed?   | number | Rate at which the layer moves in relation to scroll. Can be positive or negative. Defaults to `0`                                                 |
 
 ### Usage Notes
 
 - The `offset` prop is where the layer will end up, not where it begins. For example, if a layer has an offset of `1.5`, it will be halfway down the second page (zero-indexed) when the second page completely fills the viewport.
 - The `speed` prop will affect the initial starting position of a layer, but not it's final `offset` position.
+
+## Demo

--- a/yarn.lock
+++ b/yarn.lock
@@ -465,6 +465,14 @@
     "@react-spring/shared" "~9.1.1"
     "@react-spring/types" "~9.1.1"
 
+"@react-spring/parallax@^9.1.1":
+  version "9.1.1"
+  resolved "https://registry.yarnpkg.com/@react-spring/parallax/-/parallax-9.1.1.tgz#daee33309a96abaa232ad421eeab55564146841a"
+  integrity sha512-iV82oVoS/fF7/FchOmNVw2K1qaFuA76PzgH2xYjQwRvlyD01ZP0P3sbhZRBaD9ZaoMAgOSXB//8bE0/ogTfr4w==
+  dependencies:
+    "@react-spring/shared" "~9.1.1"
+    "@react-spring/web" "~9.1.1"
+
 "@react-spring/shared@~9.1.1":
   version "9.1.1"
   resolved "https://registry.yarnpkg.com/@react-spring/shared/-/shared-9.1.1.tgz#9f7b1a4051a0c71e0167805e7d499071b2aabddc"
@@ -2783,11 +2791,6 @@ lodash.shuffle@^4.2.0:
   resolved "https://registry.yarnpkg.com/lodash.shuffle/-/lodash.shuffle-4.2.0.tgz#145b5053cf875f6f5c2a33f48b6e9948c6ec7b4b"
   integrity sha1-FFtQU8+HX29cKjP0i26ZSMbse0s=
 
-lodash.sortby@^4.7.0:
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
-  integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
-
 lodash.truncate@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
@@ -4528,13 +4531,6 @@ toidentifier@1.0.0:
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
   integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
 
-tr46@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/tr46/-/tr46-1.0.1.tgz#a8b13fd6bfd2489519674ccde55ba3693b706d09"
-  integrity sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=
-  dependencies:
-    punycode "^2.1.1"
-
 trim-trailing-lines@^1.0.0:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/trim-trailing-lines/-/trim-trailing-lines-1.1.4.tgz#bd4abbec7cc880462f10b2c8b5ce1d8d1ec7c2c0"
@@ -4785,30 +4781,6 @@ v8-compile-cache@^2.0.3:
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"
   integrity sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==
 
-uuid@^3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
-  integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
-
-uuid@^8.3.0:
-  version "8.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
-  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
-
-v8-compile-cache@^2.0.3:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"
-  integrity sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==
-
-v8-to-istanbul@^7.0.0:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/v8-to-istanbul/-/v8-to-istanbul-7.1.1.tgz#04bfd1026ba4577de5472df4f5e89af49de5edda"
-  integrity sha512-p0BB09E5FRjx0ELN6RgusIPsSPhtgexSRcKETybEs6IGOTXJSZqfwxp7r//55nnu0f1AxltY5VvdVqy2vZf9AA==
-  dependencies:
-    "@types/istanbul-lib-coverage" "^2.0.1"
-    convert-source-map "^1.6.0"
-    source-map "^0.7.3"
-
 validate-npm-package-license@^3.0.1:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"
@@ -4863,21 +4835,14 @@ web-namespaces@^1.0.0:
   resolved "https://registry.yarnpkg.com/web-namespaces/-/web-namespaces-1.1.4.tgz#bc98a3de60dadd7faefc403d1076d529f5e030ec"
   integrity sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw==
 
-webidl-conversions@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
-  integrity sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
-
 whatwg-url@^7.0.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-7.1.0.tgz#c2c492f1eca612988efd3d2266be1b9fc6170d06"
   integrity sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==
   dependencies:
-    is-bigint "^1.0.1"
-    is-boolean-object "^1.1.0"
-    is-number-object "^1.0.4"
-    is-string "^1.0.5"
-    is-symbol "^1.0.3"
+    lodash.sortby "^4.7.0"
+    tr46 "^1.0.1"
+    webidl-conversions "^4.0.2"
 
 which-boxed-primitive@^1.0.2:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -428,22 +428,22 @@
   resolved "https://registry.yarnpkg.com/@opentelemetry/context-base/-/context-base-0.14.0.tgz#c67fc20a4d891447ca1a855d7d70fa79a3533001"
   integrity sha512-sDOAZcYwynHFTbLo6n8kIbLiVF3a3BLkrmehJUyEbT9F+Smbi47kLGS2gG2g0fjBLR/Lr1InPD7kXL7FaTqEkw==
 
-"@react-spring/animated@~9.1.1":
-  version "9.1.1"
-  resolved "https://registry.yarnpkg.com/@react-spring/animated/-/animated-9.1.1.tgz#996db774bbc42fb37838580674c4ade4f2d99f20"
-  integrity sha512-u8Assg5uySwqyoeb1f7eBAUSl8sleJTewdfhVi1EtcM9ngU2Snhcp6snF8NGxvf4gZp5z7v+Dfx3KdB2V8NnXQ==
+"@react-spring/animated@~9.1.1", "@react-spring/animated@~9.1.2":
+  version "9.1.2"
+  resolved "https://registry.yarnpkg.com/@react-spring/animated/-/animated-9.1.2.tgz#e43b122160f8f4cbb0caac8a7f57acd76dd12369"
+  integrity sha512-nKOGk+3aWbNp46V/CB1J2vR3GJI/Vork8N1WTI5mt+32QekrSsBn5/YFt4/iPaDGhLjukFxF0IjLs6hRLqSObw==
   dependencies:
-    "@react-spring/shared" "~9.1.1"
-    "@react-spring/types" "~9.1.1"
+    "@react-spring/shared" "~9.1.2"
+    "@react-spring/types" "~9.1.2"
 
-"@react-spring/core@~9.1.1":
-  version "9.1.1"
-  resolved "https://registry.yarnpkg.com/@react-spring/core/-/core-9.1.1.tgz#0d109c9f921bf957dcb65340a4192061f28e5cb2"
-  integrity sha512-flHeLN56idxQ1YIpUYY1m3r2ZAM2xg7Zb/pHBFSCbnOKP7TtlhAAOfmrabERqaThmrqkFKiq9FjyF76d3OjE5g==
+"@react-spring/core@~9.1.1", "@react-spring/core@~9.1.2":
+  version "9.1.2"
+  resolved "https://registry.yarnpkg.com/@react-spring/core/-/core-9.1.2.tgz#6d854a12fe9c3caa7942e51e708cb5fb4e2d1124"
+  integrity sha512-rgobYPCcLdDwbHBVqAmvtXhhX92G7MoPltJlzUge843yp1dNr47tkagFdCtw9NMGp6eHu/CE5byh/imlhLLAxw==
   dependencies:
-    "@react-spring/animated" "~9.1.1"
-    "@react-spring/shared" "~9.1.1"
-    "@react-spring/types" "~9.1.1"
+    "@react-spring/animated" "~9.1.2"
+    "@react-spring/shared" "~9.1.2"
+    "@react-spring/types" "~9.1.2"
 
 "@react-spring/konva@~9.1.1":
   version "9.1.1"
@@ -466,19 +466,19 @@
     "@react-spring/types" "~9.1.1"
 
 "@react-spring/parallax@^9.1.1":
-  version "9.1.1"
-  resolved "https://registry.yarnpkg.com/@react-spring/parallax/-/parallax-9.1.1.tgz#daee33309a96abaa232ad421eeab55564146841a"
-  integrity sha512-iV82oVoS/fF7/FchOmNVw2K1qaFuA76PzgH2xYjQwRvlyD01ZP0P3sbhZRBaD9ZaoMAgOSXB//8bE0/ogTfr4w==
+  version "9.1.2"
+  resolved "https://registry.yarnpkg.com/@react-spring/parallax/-/parallax-9.1.2.tgz#c5183d3baa534e513fbcb26607461097e86ebf69"
+  integrity sha512-Eh5G5nNPGKIPnh5M+FLQQeq/1TPT1YMJ8psbRKYmKPJawTFTrF3+qQ/lBkrL5yk/i3RCstA4NzGsOR8Lw8V2aA==
   dependencies:
-    "@react-spring/shared" "~9.1.1"
-    "@react-spring/web" "~9.1.1"
+    "@react-spring/shared" "~9.1.2"
+    "@react-spring/web" "~9.1.2"
 
-"@react-spring/shared@~9.1.1":
-  version "9.1.1"
-  resolved "https://registry.yarnpkg.com/@react-spring/shared/-/shared-9.1.1.tgz#9f7b1a4051a0c71e0167805e7d499071b2aabddc"
-  integrity sha512-GA9A9l5JxC50eDTDPu5IDUMhQ4MiBrXd3ZdlI6/wUCgAsZ1wPx77sxaccomxlUomRet0IUcXCEKcL1Flax7ZMQ==
+"@react-spring/shared@~9.1.1", "@react-spring/shared@~9.1.2":
+  version "9.1.2"
+  resolved "https://registry.yarnpkg.com/@react-spring/shared/-/shared-9.1.2.tgz#c36d077d7eb31fd2cbcf8956d9d35037b2998613"
+  integrity sha512-sj/RrhFZAteCWAMk+W0t6Ku/skn/lbskCCs8B7ZnHNLMGPM+Zb3MOk+aVbX3T/D0iq/oTnKWyQYqrXDKiFcZ7g==
   dependencies:
-    "@react-spring/types" "~9.1.1"
+    "@react-spring/types" "~9.1.2"
     rafz "^0.1.14"
 
 "@react-spring/three@~9.1.1":
@@ -491,20 +491,20 @@
     "@react-spring/shared" "~9.1.1"
     "@react-spring/types" "~9.1.1"
 
-"@react-spring/types@~9.1.1":
-  version "9.1.1"
-  resolved "https://registry.yarnpkg.com/@react-spring/types/-/types-9.1.1.tgz#0e53317018b81c4716a776e65477c8b0ee62758e"
-  integrity sha512-GaesYowey+nmDw/yhZ5jErEH2UaDl4jxax8aQtW5h3OpNu/QS8swoEn/jxQgffLb0n6gjsER7QyIx/dmZIWlyw==
+"@react-spring/types@~9.1.1", "@react-spring/types@~9.1.2":
+  version "9.1.2"
+  resolved "https://registry.yarnpkg.com/@react-spring/types/-/types-9.1.2.tgz#3273a182f825b38f44ead2a2f3984344abad1e2b"
+  integrity sha512-NZNImL0ymRFbss1cGKX2qSEeFdFoOgnIJZEW4Uczt+wm04J7g0Zuf23Hf8hM35JtxDr8QO5okp8BBtCM5FzzMg==
 
-"@react-spring/web@~9.1.1":
-  version "9.1.1"
-  resolved "https://registry.yarnpkg.com/@react-spring/web/-/web-9.1.1.tgz#f7ff454631d0e495887ed4631672982e1e6fb500"
-  integrity sha512-py4c/Agqz9Unf+Apame29XYTLqHnKXSwJA6Q44jcNtHRFMuRjIpCyhS13C1ZI5PcJT0g9b8CvtMQFiShne8wNQ==
+"@react-spring/web@~9.1.1", "@react-spring/web@~9.1.2":
+  version "9.1.2"
+  resolved "https://registry.yarnpkg.com/@react-spring/web/-/web-9.1.2.tgz#6ec409e8559676834b67aa33f0a2d57643c3c555"
+  integrity sha512-E5W9Hmi2bO6CPorCNV/2iv12ux9LxHJAbpXmrBPKWFRqZixysiHoNQKKPG0DmSvUU1uKkvCvMC4VoB6pj/2kxw==
   dependencies:
-    "@react-spring/animated" "~9.1.1"
-    "@react-spring/core" "~9.1.1"
-    "@react-spring/shared" "~9.1.1"
-    "@react-spring/types" "~9.1.1"
+    "@react-spring/animated" "~9.1.2"
+    "@react-spring/core" "~9.1.2"
+    "@react-spring/shared" "~9.1.2"
+    "@react-spring/types" "~9.1.2"
 
 "@react-spring/zdog@~9.1.1":
   version "9.1.1"
@@ -2791,6 +2791,11 @@ lodash.shuffle@^4.2.0:
   resolved "https://registry.yarnpkg.com/lodash.shuffle/-/lodash.shuffle-4.2.0.tgz#145b5053cf875f6f5c2a33f48b6e9948c6ec7b4b"
   integrity sha1-FFtQU8+HX29cKjP0i26ZSMbse0s=
 
+lodash.sortby@^4.7.0:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
+  integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
+
 lodash.truncate@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
@@ -4531,6 +4536,13 @@ toidentifier@1.0.0:
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
   integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
 
+tr46@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-1.0.1.tgz#a8b13fd6bfd2489519674ccde55ba3693b706d09"
+  integrity sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=
+  dependencies:
+    punycode "^2.1.0"
+
 trim-trailing-lines@^1.0.0:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/trim-trailing-lines/-/trim-trailing-lines-1.1.4.tgz#bd4abbec7cc880462f10b2c8b5ce1d8d1ec7c2c0"
@@ -4834,6 +4846,11 @@ web-namespaces@^1.0.0:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/web-namespaces/-/web-namespaces-1.1.4.tgz#bc98a3de60dadd7faefc403d1076d529f5e030ec"
   integrity sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw==
+
+webidl-conversions@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
+  integrity sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
 
 whatwg-url@^7.0.0:
   version "7.1.0"


### PR DESCRIPTION
This is a draft that adds a docs entry for Parallax. A couple of things I'm unsure of/would like a review of:

* General layout. I tried to mirror what the other pages look like, but it couldn't hurt to make sure.
* The note on only supporting `@react-spring/web`. I don't know if that is still true, I just took it from the current `README`.
* General React syntax stuff. Specifically the little sample set-up at the top. I normally use Svelte, so I don't know all the ins and outs of React yet.

Let me know if anything has to change. Thanks!