### PR TITLE
fix: add overflow auto to code blocks so that dark background isn't cut off

### DIFF
--- a/src/styles/markdown.ts
+++ b/src/styles/markdown.ts
@@ -407,6 +407,7 @@ export const MARKDOWN = /* css */ `
 .markdown-body pre {
   font-family: SFMono-Regular, Consolas, Liberation Mono, Menlo, Courier, monospace;
   font-size: 12px;
+  overflow: auto;
 }
 
 .markdown-body pre {


### PR DESCRIPTION
overflow: auto isn't added to the inner `<pre>` tags for the prism code blocks so on smaller devices the dark background colour doesn't stretch the full width 

before:
![before](https://user-images.githubusercontent.com/17256474/118008005-97271100-b344-11eb-826c-8df2e750fc14.gif)


after: 
![after](https://user-images.githubusercontent.com/17256474/118008037-9c845b80-b344-11eb-9416-73d1c453c01e.gif)
