### PR TITLE
doc(transition): fix toggle between components

### DIFF
--- a/src/pages/components/transition.mdx
+++ b/src/pages/components/transition.mdx
@@ -95,7 +95,7 @@ class Toggle extends PureComponent {
             <animated.div
               style={{
                 position: 'absolute',
-                opacity: opacity.to({ range: [0.0, 1.0], output: [0, 1] }),
+                opacity: opacity.to({ range: [0.0, 1.0], output: [1, 0] }),
               }}>
               😄
             </animated.div>


### PR DESCRIPTION
### Why
I think this exemple `toggle between two components` is not working.

### How
Just inverting those two integer in the array...

Does it make sense ?