### PR TITLE
docs(parallax): add sticky prop info

### DIFF
--- a/src/pages/components/parallax.mdx
+++ b/src/pages/components/parallax.mdx
@@ -56,6 +56,11 @@ import { Parallax, ParallaxLayer } from '@react-spring/parallax'
 `Parallax` also has a `scrollTo` function for click-to-scroll. It takes one paramater: the number of the page to scroll to
 (Pages are zero-indexed so `scrollTo(0)` will scroll to the first page, etc).
 
+### Usage Notes
+
+- `Parallax` is a scrollable container so all scroll events are fired from the container itself -- listening for scroll on `window` won't work.
+- `scrollTo` is a method on `Parallax` -- you access it with a `ref` and then `ref.current.scrollTo(pageNumber)`.
+
 ## ParallaxLayer
 
 | Property    | Type         | Description                                                                                                                                        |

--- a/src/pages/components/parallax.mdx
+++ b/src/pages/components/parallax.mdx
@@ -3,6 +3,7 @@ import { Demo } from 'components/Demo/Demo'
 
 import ParallaxVert from 'demos/parallax-vert/src/App'
 import Parallax from 'demos/parallax/src/App'
+import ParallaxSticky from 'demos/parallax-sticky/src/App'
 
 # Parallax
 
@@ -71,7 +72,6 @@ import { Parallax, ParallaxLayer } from '@react-spring/parallax'
 | horizontal? | boolean      | Whether or not the layer moves horizontally. Defaults to the `horizontal` value of `Parallax` (whose default is `false`).                          |
 | sticky?     | StickyConfig | If set, the layer will be 'sticky' between the two offsets. All other props are ignored. Default: `{start?: number = 0, end?: number = start + 1}` |
 
-
 ### Usage Notes
 
 - The `offset` prop is where the layer will end up, not where it begins. For example, if a layer has an offset of `1.5`, it will be halfway down the second page (zero-indexed) when the second page completely fills the viewport.
@@ -86,5 +86,8 @@ import { Parallax, ParallaxLayer } from '@react-spring/parallax'
   </Demo>
   <Demo title="Parallax Vert">
     <ParallaxVert />
+  </Demo>
+  <Demo title="Parallax Sticky">
+    <ParallaxSticky />
   </Demo>
 </DemoGrid>

--- a/src/pages/components/parallax.mdx
+++ b/src/pages/components/parallax.mdx
@@ -58,17 +58,20 @@ import { Parallax, ParallaxLayer } from '@react-spring/parallax'
 
 ## ParallaxLayer
 
-| Property    | Type    | Description                                                                                                                                        |
-| ----------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| factor?     | number  | Size of the layer relative to page size (eg: `1` => 100%, `1.5` => 150%, etc). Defaults to `1`.                                                    |
-| offset?     | number  | The offset of the layer when it's corresponding page is fully in view (eg: `0` => top of 1st page, `1` => top of 2nd page, etc ). Defaults to `0`. |
-| speed?      | number  | Rate at which the layer moves in relation to scroll. Can be positive or negative. Defaults to `0`.                                                 |
-| horizontal? | boolean | Whether or not the layer moves horizontally. Defaults to the `horizontal` value of `Parallax` (whose default is `false`).                          |
+| Property    | Type         | Description                                                                                                                                        |
+| ----------- | ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| factor?     | number       | Size of the layer relative to page size (eg: `1` => 100%, `1.5` => 150%, etc). Defaults to `1`.                                                    |
+| offset?     | number       | The offset of the layer when it's corresponding page is fully in view (eg: `0` => top of 1st page, `1` => top of 2nd page, etc ). Defaults to `0`. |
+| speed?      | number       | Rate at which the layer moves in relation to scroll. Can be positive or negative. Defaults to `0`.                                                 |
+| horizontal? | boolean      | Whether or not the layer moves horizontally. Defaults to the `horizontal` value of `Parallax` (whose default is `false`).                          |
+| sticky?     | StickyConfig | If set, the layer will be 'sticky' between the two offsets. All other props are ignored. Default: `{start?: number = 0, end?: number = start + 1}` |
+
 
 ### Usage Notes
 
 - The `offset` prop is where the layer will end up, not where it begins. For example, if a layer has an offset of `1.5`, it will be halfway down the second page (zero-indexed) when the second page completely fills the viewport.
 - The `speed` prop will affect the initial starting position of a layer, but not it's final `offset` position.
+- Any layer with `sticky` set will have a `z-index` higher than regular layers. This can be changed manually.
 
 ## Demos
 


### PR DESCRIPTION
- Adds information about the new `sticky` prop.
- Adds a "Usage Notes" section to `Parallax` to clear up some things that seem to come up often in Issues
  - scroll events are fired from the component and not `window`
  - basic usage of `scrollTo`

Only other thing would be to maybe add the new `sticky` demo to the iFrames at the bottom?